### PR TITLE
testnet/pizza: use https scheme for public api url in aws

### DIFF
--- a/modules/xmtp-cluster-aws/main.tf
+++ b/modules/xmtp-cluster-aws/main.tf
@@ -76,7 +76,7 @@ module "tools" {
   wait_for_ready           = false
   enable_chat_app          = var.enable_chat_app
   enable_monitoring        = var.enable_monitoring
-  public_api_url           = "http://${var.hostnames[0]}"
+  public_api_url           = "https://${var.hostnames[0]}"
   chat_app_hostnames       = local.chat_app_hostnames
   grafana_hostnames        = local.grafana_hostnames
   jaeger_hostnames         = local.jaeger_hostnames


### PR DESCRIPTION
Got the pizzanet up with chat app at https://chat.xmtp.pizza/ but it's currently erroring in chrome because of `blocked:mixed-content` since we're constructing the API url that gets passed into the chat app env with http:// instead of https://, so this PR fixes that.