### PR TITLE
Add xmptd/metrics as prometheus target

### DIFF
--- a/modules/xmtp-cluster-aws/main.tf
+++ b/modules/xmtp-cluster-aws/main.tf
@@ -4,14 +4,16 @@ locals {
   nodes_node_pool     = "xmtp-nodes"
   ingress_class_name  = "traefik"
   node_api_http_port  = 5001
+  node_admin_port     = 8009
 
   name = "${var.name_prefix}-${random_string.name_suffix.result}"
 
-  node_hostnames       = flatten([for node in var.nodes : [for hostname in var.hostnames : "${node.name}.${hostname}"]])
-  chat_app_hostnames   = [for hostname in var.hostnames : "chat.${hostname}"]
-  grafana_hostnames    = [for hostname in var.hostnames : "grafana.${hostname}"]
-  jaeger_hostnames     = [for hostname in var.hostnames : "jaeger.${hostname}"]
-  prometheus_hostnames = [for hostname in var.hostnames : "prometheus.${hostname}"]
+  node_hostnames_internal = [for node in var.nodes : "${node.name}.xmtp-nodes"]
+  node_hostnames          = flatten([for node in var.nodes : [for hostname in var.hostnames : "${node.name}.${hostname}"]])
+  chat_app_hostnames      = [for hostname in var.hostnames : "chat.${hostname}"]
+  grafana_hostnames       = [for hostname in var.hostnames : "grafana.${hostname}"]
+  jaeger_hostnames        = [for hostname in var.hostnames : "jaeger.${hostname}"]
+  prometheus_hostnames    = [for hostname in var.hostnames : "prometheus.${hostname}"]
 }
 
 data "aws_caller_identity" "current" {}
@@ -77,6 +79,8 @@ module "tools" {
   enable_chat_app          = var.enable_chat_app
   enable_monitoring        = var.enable_monitoring
   public_api_url           = "https://${var.hostnames[0]}"
+  node_admin_port          = local.node_admin_port
+  node_hostnames_internal  = local.node_hostnames_internal
   chat_app_hostnames       = local.chat_app_hostnames
   grafana_hostnames        = local.grafana_hostnames
   jaeger_hostnames         = local.jaeger_hostnames
@@ -102,4 +106,5 @@ module "nodes" {
   debug                     = true
   wait_for_ready            = false
   one_instance_per_k8s_node = false
+  admin_port                = local.node_admin_port
 }

--- a/modules/xmtp-cluster-kind/main.tf
+++ b/modules/xmtp-cluster-kind/main.tf
@@ -7,13 +7,15 @@ locals {
   cluster_https_node_port = 32443
   hostnames               = ["localhost", "xmtp.local"]
   node_api_http_port      = 5001
+  node_admin_port         = 8009
 
   name = "${var.name_prefix}-${random_string.name_suffix.result}"
 
-  chat_app_hostnames   = [for hostname in local.hostnames : "chat.${hostname}"]
-  grafana_hostnames    = [for hostname in local.hostnames : "grafana.${hostname}"]
-  jaeger_hostnames     = [for hostname in local.hostnames : "jaeger.${hostname}"]
-  prometheus_hostnames = [for hostname in local.hostnames : "prometheus.${hostname}"]
+  node_hostnames_internal = [for node in var.nodes : "${node.name}.xmtp-nodes"]
+  chat_app_hostnames      = [for hostname in local.hostnames : "chat.${hostname}"]
+  grafana_hostnames       = [for hostname in local.hostnames : "grafana.${hostname}"]
+  jaeger_hostnames        = [for hostname in local.hostnames : "jaeger.${hostname}"]
+  prometheus_hostnames    = [for hostname in local.hostnames : "prometheus.${hostname}"]
 }
 
 resource "random_string" "name_suffix" {
@@ -72,6 +74,8 @@ module "tools" {
   enable_chat_app          = var.enable_chat_app
   enable_monitoring        = var.enable_monitoring
   public_api_url           = "http://${local.hostnames[0]}"
+  node_admin_port          = local.node_admin_port
+  node_hostnames_internal  = local.node_hostnames_internal
   chat_app_hostnames       = local.chat_app_hostnames
   grafana_hostnames        = local.grafana_hostnames
   jaeger_hostnames         = local.jaeger_hostnames
@@ -97,4 +101,5 @@ module "nodes" {
   debug                     = true
   wait_for_ready            = false
   one_instance_per_k8s_node = false
+  admin_port                = local.node_admin_port
 }

--- a/modules/xmtp-cluster/nodes/_variables.tf
+++ b/modules/xmtp-cluster/nodes/_variables.tf
@@ -24,3 +24,4 @@ variable "container_storage_request" {}
 variable "container_cpu_request" {}
 variable "one_instance_per_k8s_node" { type = bool }
 variable "debug" { type = bool }
+variable "admin_port" { type = number }

--- a/modules/xmtp-cluster/nodes/main.tf
+++ b/modules/xmtp-cluster/nodes/main.tf
@@ -29,7 +29,7 @@ module "nodes_group1" {
   p2p_port                  = 9000
   api_grpc_port             = 5000
   api_http_port             = 5001
-  metrics_port              = 8009
+  admin_port                = var.admin_port
   node_pool_label_key       = var.node_pool_label_key
   node_pool                 = var.node_pool
   one_instance_per_k8s_node = var.one_instance_per_k8s_node
@@ -56,7 +56,7 @@ module "nodes_group2" {
   p2p_port                  = 9000
   api_grpc_port             = 5000
   api_http_port             = 5001
-  metrics_port              = 8009
+  admin_port                = var.admin_port
   node_pool_label_key       = var.node_pool_label_key
   node_pool                 = var.node_pool
   one_instance_per_k8s_node = var.one_instance_per_k8s_node

--- a/modules/xmtp-cluster/tools/_variables.tf
+++ b/modules/xmtp-cluster/tools/_variables.tf
@@ -5,9 +5,11 @@ variable "ingress_class_name" {}
 variable "wait_for_ready" {}
 variable "enable_chat_app" { type = bool }
 variable "enable_monitoring" { type = bool }
+variable "node_hostnames_internal" { type = list(string) }
 variable "chat_app_hostnames" { type = list(string) }
 variable "grafana_hostnames" { type = list(string) }
 variable "jaeger_hostnames" { type = list(string) }
 variable "prometheus_hostnames" { type = list(string) }
+variable "node_admin_port" { type = number }
 variable "public_api_url" {}
 variable "chat_app_container_image" {}

--- a/modules/xmtp-cluster/tools/grafana/dashboards/xmtp-network-crdt.json
+++ b/modules/xmtp-cluster/tools/grafana/dashboards/xmtp-network-crdt.json
@@ -1,391 +1,391 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 14,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "xmtpd-metrics"
         },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 0
-        },
-        "id": 2,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "xmtpd-metrics"
-            },
-            "editorMode": "code",
-            "expr": "sum(increase(xmtpd_crdt_received_events[$__rate_interval])) by (host_name, action)",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Received Events",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "xmtpd-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "scaleDistribution": {
-                "type": "linear"
-              }
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 8
-        },
-        "id": 4,
-        "options": {
-          "calculate": true,
-          "cellGap": 1,
-          "color": {
-            "exponent": 0.5,
-            "fill": "dark-orange",
-            "mode": "scheme",
-            "reverse": false,
-            "scale": "exponential",
-            "scheme": "Oranges",
-            "steps": 64
-          },
-          "exemplars": {
-            "color": "rgba(255,0,255,0.7)"
-          },
-          "filterValues": {
-            "le": 1e-9
-          },
-          "legend": {
-            "show": true
-          },
-          "rowsFrame": {
-            "layout": "auto"
-          },
-          "tooltip": {
-            "show": true,
-            "yHistogram": false
-          },
-          "yAxis": {
-            "axisPlacement": "left",
-            "reverse": false,
-            "unit": "µs"
-          }
-        },
-        "pluginVersion": "9.3.8",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "xmtpd-metrics"
-            },
-            "editorMode": "code",
-            "expr": "sum(increase(xmtpd_sync_fetch_duration_us_bucket[$__rate_interval])) by (le)",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Fetch Durations",
-        "type": "heatmap"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "xmtpd-metrics"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 16
-        },
-        "id": 6,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "xmtpd-metrics"
-            },
-            "editorMode": "code",
-            "expr": "sum(increase(xmtpd_sync_fetch_duration_us_count[$__rate_interval])) by (host_name)",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Fetch Counts",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "xmtpd-metrics"
-        },
-        "description": "Samples of (cap(ch) - len(ch)) ",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "scaleDistribution": {
-                "type": "linear"
-              }
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 24
-        },
-        "id": 8,
-        "options": {
-          "calculate": true,
-          "cellGap": 1,
-          "color": {
-            "exponent": 0.5,
-            "fill": "dark-orange",
-            "mode": "scheme",
-            "reverse": false,
-            "scale": "exponential",
-            "scheme": "Oranges",
-            "steps": 64
-          },
-          "exemplars": {
-            "color": "rgba(255,0,255,0.7)"
-          },
-          "filterValues": {
-            "le": 1e-9
-          },
-          "legend": {
-            "show": true
-          },
-          "rowsFrame": {
-            "layout": "auto"
-          },
-          "tooltip": {
-            "show": true,
-            "yHistogram": false
-          },
-          "yAxis": {
-            "axisPlacement": "left",
-            "reverse": false
-          }
-        },
-        "pluginVersion": "9.3.8",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "xmtpd-metrics"
-            },
-            "editorMode": "code",
-            "expr": "sum(increase(xmtpd_crdt_channel_free_space_bucket[$__rate_interval])) by (le)",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Channel Free Space",
-        "type": "heatmap"
+        "type": "dashboard"
       }
-    ],
-    "refresh": "10s",
-    "schemaVersion": 37,
-    "style": "dark",
-    "tags": [
-      "xmtpd"
-    ],
-    "templating": {
-      "list": []
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xmtpd-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xmtpd-metrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(xmtpd_crdt_received_events[$__rate_interval])) by (host_name, action)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Received Events",
+      "type": "timeseries"
     },
-    "time": {
-      "from": "now-1h",
-      "to": "now"
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xmtpd-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "µs"
+        }
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xmtpd-metrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(xmtpd_sync_fetch_duration_us_bucket[$__rate_interval])) by (le)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Fetch Durations",
+      "type": "heatmap"
     },
-    "timepicker": {},
-    "timezone": "",
-    "title": "CRDT Metrics",
-    "uid": "kl_JSuLVz",
-    "version": 4,
-    "weekStart": ""
-  }
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xmtpd-metrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xmtpd-metrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(xmtpd_sync_fetch_duration_us_count[$__rate_interval])) by (host_name)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Fetch Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xmtpd-metrics"
+      },
+      "description": "Samples of (cap(ch) - len(ch)) ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "percent"
+        }
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xmtpd-metrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(xmtpd_crdt_channel_free_space_bucket[$__rate_interval])) by (le)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Channel Free Space",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "xmtpd"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CRDT Metrics",
+  "uid": "kl_JSuLVz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/modules/xmtp-cluster/tools/prometheus.tf
+++ b/modules/xmtp-cluster/tools/prometheus.tf
@@ -1,6 +1,7 @@
 locals {
   prometheus_server_endpoint = "prometheus-server:80"
   prometheus_server_url      = "http://${local.prometheus_server_endpoint}"
+  node_admin_endpoints       = [for node in var.node_hostnames_internal : "${node}:${var.node_admin_port}"]
 }
 
 resource "helm_release" "prometheus" {
@@ -36,6 +37,10 @@ resource "helm_release" "prometheus" {
       prometheus-pushgateway:
         nodeSelector:
           node-pool: ${var.node_pool}
+      extraScrapeConfigs: |
+        - job_name: xmtpd
+          static_configs:
+          - targets: ${jsonencode(local.node_admin_endpoints)}
     EOF
   ]
 }

--- a/modules/xmtp-node/_variables.tf
+++ b/modules/xmtp-node/_variables.tf
@@ -10,7 +10,7 @@ variable "cpu_request" {}
 variable "p2p_port" { type = number }
 variable "api_http_port" { type = number }
 variable "api_grpc_port" { type = number }
-variable "metrics_port" { type = number }
+variable "admin_port" { type = number }
 variable "node_pool_label_key" {}
 variable "node_pool" {}
 variable "one_instance_per_k8s_node" { type = bool }

--- a/modules/xmtp-node/main.tf
+++ b/modules/xmtp-node/main.tf
@@ -55,8 +55,8 @@ resource "kubernetes_service" "service" {
       port = var.p2p_port
     }
     port {
-      name = "metrics"
-      port = var.metrics_port
+      name = "admin"
+      port = var.admin_port
     }
   }
 }
@@ -153,6 +153,7 @@ resource "kubernetes_stateful_set" "statefulset" {
               "--p2p.port=${var.p2p_port}",
               "--api.http-port=${var.api_http_port}",
               "--api.grpc-port=${var.api_grpc_port}",
+              "--admin.port=${var.admin_port}",
               "--store.type=${var.store_type}",
             ],
             [for peer in var.p2p_persistent_peers : "--p2p.persistent-peer=${peer}"],


### PR DESCRIPTION
Prerequisite for https://github.com/xmtp/xmtpd/pull/45.

I repurposed the unused `metrics_port` and turned it into `admin_port`.
The somewhat tricky part was that I needed to compute the list of internal dns names for the nodes (`node_hostnames`)  to use as the prometheus scrape targets (`node_admin_endpoints`). In the K8S world that should be just `service_name.namespace`. That is what I used for the `kind` cluster. The aws cluster already had `node_hostnames` which I'm not entirely sure what they are. Will that work?

I tested the local devnet version by changing the ref [here](https://github.com/xmtp/xmtpd/blob/main/dev/terraform/plans/devnet-local/main.tf#L2), and running `dev/apply/terraform` and spray tests on the https://github.com/xmtp/xmtpd/pull/45 branch.

The numbers do seem to look more sensible, although my love for grafana certainly hasn't grown :/

<img width="791" alt="Screenshot 2023-04-19 at 17 16 28" src="https://user-images.githubusercontent.com/871693/233202195-aababe4c-bc12-4cc6-8bad-cba284d8479b.png">
