### PR TITLE
Make sure tools resources depends on namespace for clean tear down

### DIFF
--- a/modules/xmtp-cluster/tools/datadog.tf
+++ b/modules/xmtp-cluster/tools/datadog.tf
@@ -4,7 +4,7 @@ resource "helm_release" "datadog-agent" {
   name    = "datadog-agent"
   version = "3.25.5"
 
-  namespace  = var.namespace
+  namespace  = local.namespace
   repository = "https://helm.datadoghq.com"
   chart      = "datadog"
   values = [

--- a/modules/xmtp-cluster/tools/grafana.tf
+++ b/modules/xmtp-cluster/tools/grafana.tf
@@ -3,7 +3,7 @@ resource "kubernetes_config_map" "xmtp-dashboards" {
   depends_on = [kubernetes_namespace.tools]
   metadata {
     name      = "xmtp-dashboards"
-    namespace = var.namespace
+    namespace = local.namespace
   }
   data = {
     "xmtp-network-api.json"  = file("${path.module}/grafana/dashboards/xmtp-network-api.json")
@@ -15,7 +15,7 @@ resource "helm_release" "grafana" {
   count      = var.enable_monitoring ? 1 : 0
   wait       = var.wait_for_ready
   name       = "grafana"
-  namespace  = var.namespace
+  namespace  = local.namespace
   repository = "https://grafana.github.io/helm-charts"
   version    = "6.51.2"
   chart      = "grafana"

--- a/modules/xmtp-cluster/tools/jaeger.tf
+++ b/modules/xmtp-cluster/tools/jaeger.tf
@@ -9,7 +9,7 @@ resource "helm_release" "jaeger" {
   count      = var.enable_monitoring ? 1 : 0
   wait       = var.wait_for_ready
   name       = "jaeger"
-  namespace  = var.namespace
+  namespace  = local.namespace
   repository = "https://jaegertracing.github.io/helm-charts"
   version    = "0.67.6"
   chart      = "jaeger"

--- a/modules/xmtp-cluster/tools/otelcollector.tf
+++ b/modules/xmtp-cluster/tools/otelcollector.tf
@@ -2,7 +2,7 @@ resource "helm_release" "otelcollector" {
   count      = var.enable_monitoring ? 1 : 0
   wait       = var.wait_for_ready
   name       = "otelcollector"
-  namespace  = var.namespace
+  namespace  = local.namespace
   repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
   version    = "0.49.1"
   chart      = "opentelemetry-collector"

--- a/modules/xmtp-cluster/tools/prometheus.tf
+++ b/modules/xmtp-cluster/tools/prometheus.tf
@@ -8,7 +8,7 @@ resource "helm_release" "prometheus" {
   count      = var.enable_monitoring ? 1 : 0
   wait       = var.wait_for_ready
   name       = "prometheus"
-  namespace  = var.namespace
+  namespace  = local.namespace
   repository = "https://prometheus-community.github.io/helm-charts"
   version    = "19.7.2"
   chart      = "prometheus"


### PR DESCRIPTION
The modules aren't always tearing down cleanly because a few of the tools resources aren't depending on the namespace, so the namespace is sometimes deleted before the helm charts are removed, causing the helm removal to error. This PR fixes that by referencing the output of the kubernetes_namespace resource, so that the dependency is encoded.