### PR TITLE
Re-enable chat app in dev/plans/devnet-local

### DIFF
--- a/dev/plans/devnet-local/main.tf
+++ b/dev/plans/devnet-local/main.tf
@@ -3,7 +3,7 @@ module "cluster" {
 
   name_prefix          = "xmtp-devnet"
   node_container_image = "xmtp/xmtpd:latest"
-  enable_chat_app      = false
+  enable_chat_app      = true
   enable_monitoring    = true
   ingress_http_port    = 80
   ingress_https_port   = 443


### PR DESCRIPTION
Re-enable chat app in dev/plans/devnet-local now that the docker image is being published reliably