### PR TITLE
aws: create_before_destroy=true on eks node groups

### DIFF
--- a/modules/xmtp-cluster-aws/k8s/main.tf
+++ b/modules/xmtp-cluster-aws/k8s/main.tf
@@ -114,4 +114,8 @@ module "eks_node_group" {
 
   # Prevent the node groups from being created before the Kubernetes aws-auth ConfigMap
   module_depends_on = module.eks_cluster.kubernetes_config_map_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
When updating the node groups in a way where they need to be replaced, we should create the new group before destroying the old group so workloads remain available.