### PR TITLE
aws: expose variable for node pool size

### DIFF
--- a/modules/xmtp-cluster-aws/_variables.tf
+++ b/modules/xmtp-cluster-aws/_variables.tf
@@ -76,6 +76,14 @@ variable "nodes_node_pool_instance_type" {
   default = "t3.small"
 }
 
+variable "system_node_pool_desired_size" {
+  default = 2
+}
+
+variable "nodes_node_pool_desired_size" {
+  default = 2
+}
+
 variable "container_storage_request" { default = "1Gi" }
 variable "container_cpu_request" { default = "100m" }
 variable "container_memory_request" { default = "400Mi" }

--- a/modules/xmtp-cluster-aws/main.tf
+++ b/modules/xmtp-cluster-aws/main.tf
@@ -39,7 +39,7 @@ module "k8s" {
     {
       name           = local.system_node_pool
       instance_types = [var.system_node_pool_instance_type]
-      desired_size   = 2
+      desired_size   = var.system_node_pool_desired_size
       labels = {
         (local.node_pool_label_key) = local.system_node_pool
       }
@@ -47,7 +47,7 @@ module "k8s" {
     {
       name           = local.nodes_node_pool
       instance_types = [var.nodes_node_pool_instance_type]
-      desired_size   = 2
+      desired_size   = var.nodes_node_pool_desired_size
       labels = {
         (local.node_pool_label_key) = local.nodes_node_pool
       }


### PR DESCRIPTION
Expose variables on the AWS cluster module for node pool size (number of nodes).