### PR TITLE
aws: tag ingress service cluster name for DD metrics

### DIFF
--- a/modules/xmtp-cluster-aws/main.tf
+++ b/modules/xmtp-cluster-aws/main.tf
@@ -66,6 +66,9 @@ module "system" {
   node_pool            = local.system_node_pool
   ingress_class_name   = local.ingress_class_name
   ingress_service_type = "LoadBalancer"
+  ingress_service_annotations = {
+    "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" = "cluster=${local.name},cluster_name=${var.datadog_cluster_name}"
+  }
 }
 
 module "tools" {

--- a/modules/xmtp-cluster-kind/main.tf
+++ b/modules/xmtp-cluster-kind/main.tf
@@ -53,13 +53,14 @@ module "system" {
   source     = "../xmtp-cluster/system"
   depends_on = [module.k8s]
 
-  namespace               = "xmtp-system"
-  node_pool_label_key     = local.node_pool_label_key
-  node_pool               = local.system_node_pool
-  cluster_http_node_port  = local.cluster_http_node_port
-  cluster_https_node_port = local.cluster_https_node_port
-  ingress_class_name      = local.ingress_class_name
-  ingress_service_type    = "NodePort"
+  namespace                   = "xmtp-system"
+  node_pool_label_key         = local.node_pool_label_key
+  node_pool                   = local.system_node_pool
+  cluster_http_node_port      = local.cluster_http_node_port
+  cluster_https_node_port     = local.cluster_https_node_port
+  ingress_class_name          = local.ingress_class_name
+  ingress_service_type        = "NodePort"
+  ingress_service_annotations = {}
 }
 
 module "tools" {

--- a/modules/xmtp-cluster/system/_variables.tf
+++ b/modules/xmtp-cluster/system/_variables.tf
@@ -11,3 +11,4 @@ variable "cluster_https_node_port" {
 }
 variable "ingress_class_name" {}
 variable "ingress_service_type" {}
+variable "ingress_service_annotations" { type = map(string) }

--- a/modules/xmtp-cluster/system/traefik.tf
+++ b/modules/xmtp-cluster/system/traefik.tf
@@ -42,6 +42,7 @@ resource "helm_release" "traefik" {
       service:
         enabled: false
         type: ${var.ingress_service_type}
+        annotations: ${yamlencode(var.ingress_service_annotations)}
       nodeSelector:
         ${var.node_pool_label_key}: ${var.node_pool}
       providers:


### PR DESCRIPTION
The ELB metrics in DD are missing a way to group by the associated cluster, so this PR adds that via the ingress service annotations.